### PR TITLE
fixed follow page pagination broken problem

### DIFF
--- a/app/controllers/pens_controller.rb
+++ b/app/controllers/pens_controller.rb
@@ -105,5 +105,6 @@ class PensController < ApplicationController
 
   def pens_per_page(pens)
     @pens = Kaminari.paginate_array(pens).page(params[:page]).per(6)
+    @pens = Kaminari.paginate_array(pens).page(1).per(6) if @pens.prev_page.nil?
   end
 end


### PR DESCRIPTION
closes #342 
- 修正當follow頁面的Pen數量不足以構成有第二頁以上時，跳轉發生錯誤的情形