### PR TITLE
fixed trending, follow, search all user page should not show private pen

### DIFF
--- a/app/controllers/pens_controller.rb
+++ b/app/controllers/pens_controller.rb
@@ -54,7 +54,7 @@ class PensController < ApplicationController
 
   def search_all_users
     begin
-      pens = Pen.search(params[:q]).includes(:user).where.not(user: current_user)
+      pens = Pen.search(params[:q]).includes(:user).where.not(user: current_user, private: true)
       pens_per_page(pens)
 
       respond_to do |format|
@@ -62,7 +62,7 @@ class PensController < ApplicationController
         format.html { render :search_all_users }
       end
     rescue
-      pens = Pen.includes(:user).where.not(user: current_user)
+      pens = Pen.includes(:user).where.not(user: current_user, private: true)
       pens_per_page(pens)
 
       respond_to do |format|
@@ -76,7 +76,7 @@ class PensController < ApplicationController
     begin
       pens = Pen.joins(user: {follower_relationships: :following})
                 .includes(:user)
-                .where(user: current_user.following)
+                .where(user: current_user.following, private: false)
 
       pens_per_page(pens)
 
@@ -87,7 +87,7 @@ class PensController < ApplicationController
     rescue
       pens = Pen.joins(user: {follower_relationships: :following})
                  .includes(:user)
-                 .where.not(user: current_user)
+                 .where.not(user: current_user, private: true)
                  .distinct
 
       pens_per_page(pens)
@@ -102,13 +102,13 @@ class PensController < ApplicationController
   def trending
       most_viewed_pens = Pen.joins(:impressions)
                             .where("impressions.created_at": 1.day.ago..Time.now)
-                            .where.not(user: current_user)
+                            .where.not(user: current_user, private: true)
                             .group("pens.id")
                             .order("count(pens.id) DESC")
 
       most_follower_pens = Pen.joins(user: {follower_relationships: :following})
                               .includes(:user)
-                              .where.not(user: current_user)
+                              .where.not(user: current_user, private: true)
                               .group("pens.id")
                               .order("count(follows.following_id) DESC")
 

--- a/app/controllers/pens_controller.rb
+++ b/app/controllers/pens_controller.rb
@@ -54,7 +54,12 @@ class PensController < ApplicationController
 
   def search_all_users
     begin
-      pens = Pen.search(params[:q]).includes(:user).where.not(user: current_user, private: true)
+      pens = Pen.search(params[:q])
+                .includes(:user)
+                .where.not(user: current_user)
+                .where.not(private: true)
+                .order(updated_at: :desc)
+
       pens_per_page(pens)
 
       respond_to do |format|
@@ -62,7 +67,11 @@ class PensController < ApplicationController
         format.html { render :search_all_users }
       end
     rescue
-      pens = Pen.includes(:user).where.not(user: current_user, private: true)
+      pens = Pen.includes(:user)
+                .where.not(user: current_user)
+                .where.not(private: true)
+                .order(updated_at: :desc)
+
       pens_per_page(pens)
 
       respond_to do |format|
@@ -73,53 +82,43 @@ class PensController < ApplicationController
   end
 
   def follow
-    begin
-      pens = Pen.joins(user: {follower_relationships: :following})
-                .includes(:user)
-                .where(user: current_user.following, private: false)
+    pens = Pen.joins(user: {follower_relationships: :following})
+              .includes(:user)
+              .where(user: current_user.following, private: false)
+              .order(updated_at: :desc)
+              .distinct
 
-      pens_per_page(pens)
+    pens_per_page(pens)
 
-      respond_to do |format|
-        format.json { render json: pens_per_page(pens) }
-        format.html { render :follow }
-      end
-    rescue
-      pens = Pen.joins(user: {follower_relationships: :following})
-                 .includes(:user)
-                 .where.not(user: current_user, private: true)
-                 .distinct
-
-      pens_per_page(pens)
-
-      respond_to do |format|
-        format.json { render json: pens_per_page(pens) }
-        format.html { render :follow }
-      end
+    respond_to do |format|
+      format.json { render json: pens_per_page(pens) }
+      format.html { render :follow }
     end
   end
 
   def trending
-      most_viewed_pens = Pen.joins(:impressions)
-                            .where("impressions.created_at": 1.day.ago..Time.now)
-                            .where.not(user: current_user, private: true)
+    most_viewed_pens = Pen.joins(:impressions)
+                          .where("impressions.created_at": 1.day.ago..Time.now)
+                          .where.not(user: current_user)
+                          .where.not(private: true)
+                          .group("pens.id")
+                          .order("count(pens.id) DESC")
+
+    most_follower_pens = Pen.joins(user: {follower_relationships: :following})
+                            .includes(:user)
+                            .where.not(user: current_user)
+                            .where.not(private: true)
                             .group("pens.id")
-                            .order("count(pens.id) DESC")
+                            .order("count(follows.following_id) DESC")
 
-      most_follower_pens = Pen.joins(user: {follower_relationships: :following})
-                              .includes(:user)
-                              .where.not(user: current_user, private: true)
-                              .group("pens.id")
-                              .order("count(follows.following_id) DESC")
+    pens = (most_viewed_pens.first(50) + most_follower_pens.first(50)).uniq
 
-      pens = (most_viewed_pens.first(50) + most_follower_pens.first(50)).uniq
+    pens_per_page(pens)
 
-      pens_per_page(pens)
-
-      respond_to do |format|
-        format.json { render json: pens_per_page(pens) }
-        format.html { render :trending }
-      end
+    respond_to do |format|
+      format.json { render json: pens_per_page(pens) }
+      format.html { render :trending }
+    end
   end
 
   private


### PR DESCRIPTION
closes #370
- 修正trending, follow, search all user page看的到私人筆(應該要看不到)
- 修正list頁面鎖頭跑到第二行